### PR TITLE
Better support for PyG

### DIFF
--- a/graphormer_pretrained/data/pyg_datasets/pyg_dataset.py
+++ b/graphormer_pretrained/data/pyg_datasets/pyg_dataset.py
@@ -100,5 +100,11 @@ class GraphormerPYGDataset(Dataset):
         else:
             raise TypeError("index to a GraphormerPYGDataset can only be an integer.")
 
+    def get(self, idx):
+        return self[idx]
+
+    def len(self):
+        return self.num_data
+
     def __len__(self):
         return self.num_data

--- a/news/pyg.rst
+++ b/news/pyg.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for recent versions of pyg that changed Dataset structure
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@hadim PyG changed their Dataset class structure recently, which leads to failure to use graphormer in molfeat.
